### PR TITLE
feat: Sprint 4 - 統計表示機能の実装 (Phase 1)

### DIFF
--- a/.claude/progress.md
+++ b/.claude/progress.md
@@ -837,31 +837,173 @@ test('編集中に削除確認を開くことができる（状態競合のテ�
 
 ---
 
-## 📊 Sprint 4: エンゲージメント機能（計画中）
+## 🎉 Sprint 4: エンゲージメント機能（完了）
 
-### 4.1 統計・インサイト表示
+### 実装期間
+2026-01-08（1日）
 
-**実装内容**:
-1. 記録連続日数（ストリーク）
-2. 総記録数
-3. 月間カレンダービュー（記録した日をハイライト）
-4. よく使う言葉の頻出ワード表示（簡易版）
+### 完了した作業
 
-**新規ファイル**:
-- `/src/components/Stats/StatsView.tsx` - 統計表示画面
-- `/src/components/Stats/StreakCounter.tsx` - ストリークカウンター
-- `/src/components/Stats/MonthlyCalendar.tsx` - 月間カレンダー
-- `/src/components/Stats/Stats.css`
-- `/src/utils/statsCalculator.ts` - 統計計算ロジック
-
-**変更ファイル**:
-- [src/App.tsx](src/App.tsx) - 統計ビュー追加（3つ目のタブ）
-
-**期待効果**: 継続率+25%見込み
-
-### 4.2 リマインダー機能（オプション）
+#### 4.1 統計・インサイト表示（Phase 1）✅
 
 **実装内容**:
+- 連続記録日数（ストリーク）カウンター 🔥
+- 総記録日数表示 📅
+- 記録した良いこと（総項目数）✨
+- 今週の記録数 📊
+- 今月の記録数 📆
+
+**新規ファイル（5つ）**:
+- [src/utils/statsCalculator.ts](src/utils/statsCalculator.ts) - 統計計算ロジック（5つの計算関数）
+- [src/components/StatsView/StatsView.tsx](src/components/StatsView/StatsView.tsx) - 統計表示コンポーネント
+- [src/components/StatsView/StatsView.css](src/components/StatsView/StatsView.css) - Material Design 3スタイル
+- [src/utils/__tests__/statsCalculator.test.ts](src/utils/__tests__/statsCalculator.test.ts) - ユニットテスト（11テスト）
+- [src/components/StatsView/__tests__/StatsView.test.tsx](src/components/StatsView/__tests__/StatsView.test.tsx) - コンポーネントテスト（5テスト）
+
+**変更ファイル（3つ）**:
+- [src/hooks/useEntryView.ts](src/hooks/useEntryView.ts) - ViewTypeに'stats'を追加（3タブ対応）
+- [src/App.tsx](src/App.tsx) - 統計タブとStatsView統合
+- [src/App.css](src/App.css) - 3タブ対応スタイル調整
+
+**統計計算ロジック**:
+```typescript
+// 連続記録日数（ストリーク）
+calculateStreak(entries): number
+  - 今日または昨日から連続して記録している日数を計算
+  - 今日も昨日も記録がない場合は0を返す
+
+// 総記録日数
+countTotalEntries(entries): number
+
+// 今週の記録数（日曜日始まり）
+countThisWeekEntries(entries): number
+
+// 今月の記録数
+countThisMonthEntries(entries): number
+
+// 総項目数（1日3項目 × 記録日数）
+countTotalItems(entries): number
+```
+
+**UIデザイン**:
+- **プライマリカード（ストリーク）**: グラデーション背景（紫系）で目立たせる
+- **サブ統計グリッド**: 2×2レイアウトで4つの指標を表示
+- **ホバーエフェクト**: translateY(-4px) + shadow変化
+- **レスポンシブデザイン**: タブレット・スマホ対応
+- **ダークテーマ対応**: プライマリカードのグラデーションが自動切り替え
+- **アクセシビリティ**: ARIA属性、キーボードナビゲーション
+
+**エンプティステート**:
+- 記録がない場合: 「まだ記録がありません」
+- 誘導メッセージ: 「『今日の記録』タブから、今日の良いことを3つ記録してみましょう！」
+
+**技術的ハイライト**:
+```typescript
+// useMemoで統計計算をメモ化（パフォーマンス最適化）
+const stats = useMemo(() => {
+  return {
+    streak: calculateStreak(entries),
+    totalEntries: countTotalEntries(entries),
+    thisWeekEntries: countThisWeekEntries(entries),
+    thisMonthEntries: countThisMonthEntries(entries),
+    totalItems: countTotalItems(entries)
+  };
+}, [entries]);
+```
+
+---
+
+### Git管理
+
+**ブランチ**: `feat/sprint4-stats-view`
+**統計**:
+- 新規ファイル: 5つ
+- 変更ファイル: 3つ
+- 新規テスト: +16テスト
+
+---
+
+### テスト結果
+
+**改善後**:
+- テスト総数: 92 tests (+16 tests)
+- パス率: **100%** (92/92 tests)
+- 失敗: 0 tests
+
+**新規テスト内訳**:
+- statsCalculator: 11 tests
+  - calculateStreak: 5 tests（今日記録あり、昨日記録あり、記録なし、空配列、連続でない記録）
+  - countTotalEntries: 2 tests
+  - countTotalItems: 2 tests
+  - countThisWeekEntries: 1 test
+  - countThisMonthEntries: 1 test
+- StatsView: 5 tests
+  - ローディング状態
+  - 統計データ表示
+  - ストリーク0の場合
+  - エンプティステート
+  - ARIA属性
+
+---
+
+### 成功基準の達成
+
+✅ 統計タブが「今日/履歴」と同じパターンで実装されている
+✅ ストリーク計算が正確（今日/昨日の記録に基づく）
+✅ 総記録数・今週・今月の統計が正確
+✅ Material Design 3のスタイルが適用されている
+✅ ダークモードで正常に表示される
+✅ ARIA属性が適切に設定されている
+✅ テストが全パスする（100%）
+✅ TypeScriptエラーがない
+✅ 本番ビルドが成功する
+
+---
+
+### 期待効果
+
+- 継続率 +25% 見込み
+- ユーザーエンゲージメント向上
+- ポジティブな習慣化の促進
+- 記録する動機づけの強化
+
+---
+
+### 学んだこと
+
+**統計計算の設計**:
+- **日付処理の標準化**: YYYY-MM-DD形式で統一することで、文字列比較で正確に日付順序を取得可能
+- **ストリーク計算のロジック**: 今日または昨日に記録がない場合はストリーク0とすることで、直感的な動作を実現
+- **useMemoによる最適化**: 統計計算は重い処理になる可能性があるため、メモ化が重要
+
+**Material Design 3の活用**:
+- **グラデーション背景**: プライマリカラーの濃淡でグラデーションを作ることで、視覚的に目立つカードを実現
+- **エレベーション**: ホバー時にtranslateYとshadowを変化させることで、インタラクティブな体験を提供
+- **グリッドレイアウト**: repeat(auto-fit, minmax())を使うことで、柔軟なレスポンシブデザインを実現
+
+**テスト設計**:
+- **境界値テストの重要性**: ストリーク計算では、今日記録あり/昨日記録あり/記録なしの3パターンをテスト
+- **日付依存のテスト**: 今週・今月のテストは、動的に日付を生成することで、いつ実行しても正しくテストできる
+
+---
+
+### 将来の拡張（Phase 2, 3）
+
+**Phase 2: 月間カレンダービュー**（将来実装）:
+- カレンダーグリッド（7×6）
+- 記録した日をハイライト表示
+- 月切り替えボタン
+
+**Phase 3: 頻出ワード表示**（将来実装）:
+- テキスト解析（MeCab.js or kuromoji.js）
+- 頻出ワードトップ10リスト
+- シンプルなリスト表示（簡易版）
+
+---
+
+### 4.2 リマインダー機能（オプション・未実装）
+
+**実装内容**（将来実装予定）:
 1. 毎日決まった時間にプッシュ通知
 2. Service Worker経由
 3. 通知設定画面
@@ -895,23 +1037,27 @@ test('編集中に削除確認を開くことができる（状態競合のテ�
 **Sprint 3** (パフォーマンス + リファクタ):
 - [x] App.tsxリファクタリング
 - [x] パフォーマンス最適化
-
-### 次のステップ 📝
+- [x] テスト拡充（97%パス率達成）
 
 **Sprint 4** (エンゲージメント機能):
-- [ ] 統計・インサイト表示
-- [ ] リマインダー機能（オプション）
+- [x] 統計・インサイト表示（Phase 1）
+- [ ] 月間カレンダービュー（Phase 2・将来実装）
+- [ ] 頻出ワード表示（Phase 3・将来実装）
+- [ ] リマインダー機能（オプション・将来実装）
 
 ### テスト状況
-- **現在**: 41/50 tests passing (82%)
-- **残課題**: 9件のReact act()警告とタイムアウト（機能的な問題なし）
+- **現在**: 92/92 tests passing (**100%**)
+- **新規テスト**: +16 tests（statsCalculator + StatsView）
+- **残課題**: なし
 
 ---
 
-## 🎯 実装の優先順位
+## 🎯 次のステップ
 
-1. **Sprint 4** (エンゲージメント) - 計画中
-   - 統計表示 → リマインダー（オプション）
+**Phase 2 & 3 の実装** (オプション):
+- 月間カレンダービュー（記録した日をハイライト）
+- 頻出ワード表示（よく使う言葉のトップ10）
+- リマインダー機能（プッシュ通知）
 
 ---
 
@@ -919,5 +1065,6 @@ test('編集中に削除確認を開くことができる（状態競合のテ�
 
 - 各Sprint完了後はテスト実行・動作確認を実施
 - Git commitは論理的な単位で分割
+- Sprint 4 Phase 1完了により、基本的なエンゲージメント機能が実装完了
 
-**最終更新**: 2026-01-07
+**最終更新**: 2026-01-08

--- a/src/App.css
+++ b/src/App.css
@@ -143,10 +143,10 @@
 
 .view-button {
   flex: 1;
-  padding: 0.8rem;
+  padding: 0.8rem 0.5rem;
   border: none;
   background-color: transparent;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   font-weight: 500;
   letter-spacing: 0.5px;
   text-transform: uppercase;
@@ -155,6 +155,7 @@
   z-index: 1;
   border-radius: 0;
   color: var(--md-on-surface-variant);
+  transition: color var(--md-transition-standard), background-color var(--md-transition-standard);
 }
 
 .view-button:hover {
@@ -183,6 +184,12 @@
   max-width: 1200px;
   margin: 0 auto;
   width: 100%;
+}
+
+/* 統計ビューコンテナ */
+.stats-view-container {
+  width: 100%;
+  padding: 0;
 }
 
 /* 履歴ビュー */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { EntryList } from './components/EntryList/EntryList';
 import { ThemeToggle } from './components/ThemeToggle/ThemeToggle';
 import { ConfirmDialog } from './components/ConfirmDialog/ConfirmDialog';
 import { ExportDialog } from './components/ExportDialog/ExportDialog';
+import { StatsView } from './components/StatsView/StatsView';
 import { useEntries } from './hooks/useEntries';
 import { useEntryView } from './hooks/useEntryView';
 import { useEntryEditing } from './hooks/useEntryEditing';
@@ -157,6 +158,16 @@ function App() {
         >
           履歴
         </button>
+        <button
+          id="stats-tab"
+          className={`view-button ${activeView === 'stats' ? 'active' : ''}`}
+          onClick={() => setActiveView('stats')}
+          role="tab"
+          aria-selected={activeView === 'stats'}
+          aria-controls="stats-panel"
+        >
+          統計
+        </button>
       </nav>
 
       {activeView === 'today' && (
@@ -215,7 +226,7 @@ function App() {
           {selectedEntry && (
             <div className="selected-entry">
               <h2>{formatDate(selectedEntry.date)}の記録</h2>
-              
+
               <div className="entry-items-with-comments">
                 {selectedEntry.items.map((item, index) => (
                   <div key={index} className="entry-item-with-comment">
@@ -223,7 +234,7 @@ function App() {
                       <div className="item-number">{index + 1}.</div>
                       <div className="item-content">{item.content}</div>
                     </div>
-                    
+
                     <div className="item-comment">
                       <AiCommentItem
                         key={`${selectedEntry.date}-item-${index}`}
@@ -241,6 +252,17 @@ function App() {
             </div>
           )}
           </div>
+        </main>
+      )}
+
+      {activeView === 'stats' && (
+        <main
+          id="main-content"
+          className="stats-view-container"
+          role="tabpanel"
+          aria-labelledby="stats-tab"
+        >
+          <StatsView entries={allEntries} isLoading={isLoading} />
         </main>
       )}
 

--- a/src/components/StatsView/StatsView.css
+++ b/src/components/StatsView/StatsView.css
@@ -1,0 +1,165 @@
+/* StatsView - Material Design 3準拠 */
+
+.stats-view {
+  padding: 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.stats-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--md-on-background);
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+/* ローディング状態 */
+.stats-view.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  color: var(--md-on-surface-variant);
+}
+
+/* プライマリカード（ストリーク） */
+.stat-card.primary-card {
+  background: linear-gradient(135deg, var(--md-primary) 0%, var(--md-primary-dark) 100%);
+  color: var(--md-on-primary);
+  padding: 2rem;
+  border-radius: 24px;
+  box-shadow: var(--md-shadow-2);
+  margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  transition: transform var(--md-transition-standard), box-shadow var(--md-transition-standard);
+}
+
+.stat-card.primary-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--md-shadow-3);
+}
+
+.primary-card .stat-icon {
+  font-size: 4rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.primary-card .stat-label {
+  font-size: 1rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+  opacity: 0.9;
+}
+
+.primary-card .stat-value.large {
+  font-size: 3.5rem;
+  font-weight: 700;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+}
+
+.primary-card .stat-unit {
+  font-size: 1.5rem;
+  font-weight: 400;
+  margin-left: 0.25rem;
+}
+
+.primary-card .stat-description {
+  font-size: 0.95rem;
+  opacity: 0.9;
+  line-height: 1.4;
+}
+
+/* サブ統計グリッド */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* サブカード */
+.stat-card {
+  background-color: var(--md-surface);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: var(--md-shadow-1);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  transition: transform var(--md-transition-standard), box-shadow var(--md-transition-standard);
+}
+
+.stat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--md-shadow-2);
+}
+
+.stat-icon.small {
+  font-size: 2.5rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.stat-content {
+  flex: 1;
+}
+
+.stat-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--md-on-surface-variant);
+  margin-bottom: 0.25rem;
+}
+
+.stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--md-on-surface);
+  line-height: 1;
+}
+
+.stat-unit {
+  font-size: 1rem;
+  font-weight: 400;
+  color: var(--md-on-surface-variant);
+  margin-left: 0.25rem;
+}
+
+/* エンプティステート */
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  margin-top: 2rem;
+  background-color: var(--md-surface);
+  border-radius: 16px;
+  box-shadow: var(--md-shadow-1);
+}
+
+.empty-message {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--md-on-surface);
+  margin-bottom: 0.5rem;
+}
+
+.empty-description {
+  font-size: 1rem;
+  color: var(--md-on-surface-variant);
+  line-height: 1.5;
+}
+
+/* ダークテーマ対応 */
+:root[data-theme="dark"] .stat-card.primary-card {
+  background: linear-gradient(135deg, var(--md-primary-light) 0%, var(--md-primary) 100%);
+}

--- a/src/components/StatsView/StatsView.tsx
+++ b/src/components/StatsView/StatsView.tsx
@@ -1,0 +1,105 @@
+import React, { useMemo } from 'react';
+import type { DailyEntry } from '../../types';
+import {
+  calculateStreak,
+  countTotalEntries,
+  countThisWeekEntries,
+  countThisMonthEntries,
+  countTotalItems
+} from '../../utils/statsCalculator';
+import './StatsView.css';
+
+interface StatsViewProps {
+  entries: DailyEntry[];
+  isLoading: boolean;
+}
+
+export const StatsView: React.FC<StatsViewProps> = ({ entries, isLoading }) => {
+  // 統計データをメモ化（エントリーが変わらない限り再計算しない）
+  const stats = useMemo(() => {
+    return {
+      streak: calculateStreak(entries),
+      totalEntries: countTotalEntries(entries),
+      thisWeekEntries: countThisWeekEntries(entries),
+      thisMonthEntries: countThisMonthEntries(entries),
+      totalItems: countTotalItems(entries)
+    };
+  }, [entries]);
+
+  if (isLoading) {
+    return (
+      <div className="stats-view loading" role="status" aria-live="polite">
+        <p>統計を読み込んでいます...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="stats-view" role="region" aria-label="統計情報">
+      <h2 className="stats-title">あなたの記録統計</h2>
+
+      {/* メイン統計カード: ストリーク */}
+      <div className="stat-card primary-card" role="article" aria-labelledby="streak-title">
+        <div className="stat-icon">🔥</div>
+        <div className="stat-content">
+          <h3 id="streak-title" className="stat-label">連続記録日数</h3>
+          <p className="stat-value large">{stats.streak}<span className="stat-unit">日</span></p>
+          <p className="stat-description">
+            {stats.streak === 0
+              ? '今日から記録を始めましょう！'
+              : `素晴らしい！${stats.streak}日連続で記録を続けています`}
+          </p>
+        </div>
+      </div>
+
+      {/* サブ統計カード群 */}
+      <div className="stats-grid">
+        {/* 総記録数 */}
+        <div className="stat-card" role="article" aria-labelledby="total-entries-title">
+          <div className="stat-icon small">📅</div>
+          <div className="stat-content">
+            <h3 id="total-entries-title" className="stat-label">総記録日数</h3>
+            <p className="stat-value">{stats.totalEntries}<span className="stat-unit">日</span></p>
+          </div>
+        </div>
+
+        {/* 総項目数 */}
+        <div className="stat-card" role="article" aria-labelledby="total-items-title">
+          <div className="stat-icon small">✨</div>
+          <div className="stat-content">
+            <h3 id="total-items-title" className="stat-label">記録した良いこと</h3>
+            <p className="stat-value">{stats.totalItems}<span className="stat-unit">個</span></p>
+          </div>
+        </div>
+
+        {/* 今週の記録数 */}
+        <div className="stat-card" role="article" aria-labelledby="week-entries-title">
+          <div className="stat-icon small">📊</div>
+          <div className="stat-content">
+            <h3 id="week-entries-title" className="stat-label">今週の記録</h3>
+            <p className="stat-value">{stats.thisWeekEntries}<span className="stat-unit">日</span></p>
+          </div>
+        </div>
+
+        {/* 今月の記録数 */}
+        <div className="stat-card" role="article" aria-labelledby="month-entries-title">
+          <div className="stat-icon small">📆</div>
+          <div className="stat-content">
+            <h3 id="month-entries-title" className="stat-label">今月の記録</h3>
+            <p className="stat-value">{stats.thisMonthEntries}<span className="stat-unit">日</span></p>
+          </div>
+        </div>
+      </div>
+
+      {/* エンプティステート（記録がない場合） */}
+      {stats.totalEntries === 0 && (
+        <div className="empty-state">
+          <p className="empty-message">まだ記録がありません</p>
+          <p className="empty-description">
+            「今日の記録」タブから、今日の良いことを3つ記録してみましょう！
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/StatsView/__tests__/StatsView.test.tsx
+++ b/src/components/StatsView/__tests__/StatsView.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { StatsView } from '../StatsView';
+import { DailyEntry } from '../../../types';
+
+// statsCalculator のモック
+jest.mock('../../../utils/statsCalculator', () => ({
+  calculateStreak: jest.fn(),
+  countTotalEntries: jest.fn(),
+  countThisWeekEntries: jest.fn(),
+  countThisMonthEntries: jest.fn(),
+  countTotalItems: jest.fn()
+}));
+
+import * as statsCalculator from '../../../utils/statsCalculator';
+
+describe('StatsView', () => {
+  const mockEntries: DailyEntry[] = [
+    {
+      date: '2024-01-01',
+      items: [
+        { content: '良いこと1', createdAt: new Date('2024-01-01'), hasRequestedComment: false },
+        { content: '良いこと2', createdAt: new Date('2024-01-01'), hasRequestedComment: false },
+        { content: '良いこと3', createdAt: new Date('2024-01-01'), hasRequestedComment: false }
+      ]
+    }
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('ローディング状態を正しく表示する', () => {
+    render(<StatsView entries={[]} isLoading={true} />);
+    expect(screen.getByText('統計を読み込んでいます...')).toBeInTheDocument();
+  });
+
+  test('統計データを正しく表示する', () => {
+    // モック設定
+    (statsCalculator.calculateStreak as jest.Mock).mockReturnValue(5);
+    (statsCalculator.countTotalEntries as jest.Mock).mockReturnValue(10);
+    (statsCalculator.countThisWeekEntries as jest.Mock).mockReturnValue(3);
+    (statsCalculator.countThisMonthEntries as jest.Mock).mockReturnValue(7);
+    (statsCalculator.countTotalItems as jest.Mock).mockReturnValue(30);
+
+    render(<StatsView entries={mockEntries} isLoading={false} />);
+
+    // ストリーク表示確認
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText(/素晴らしい！5日連続/)).toBeInTheDocument();
+
+    // 総記録数表示確認
+    expect(screen.getByText('10')).toBeInTheDocument();
+
+    // 総項目数表示確認
+    expect(screen.getByText('30')).toBeInTheDocument();
+
+    // 今週の記録数表示確認
+    expect(screen.getByText('3')).toBeInTheDocument();
+
+    // 今月の記録数表示確認
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  test('ストリークが0の場合、適切なメッセージを表示する', () => {
+    (statsCalculator.calculateStreak as jest.Mock).mockReturnValue(0);
+    (statsCalculator.countTotalEntries as jest.Mock).mockReturnValue(0);
+    (statsCalculator.countThisWeekEntries as jest.Mock).mockReturnValue(0);
+    (statsCalculator.countThisMonthEntries as jest.Mock).mockReturnValue(0);
+    (statsCalculator.countTotalItems as jest.Mock).mockReturnValue(0);
+
+    render(<StatsView entries={[]} isLoading={false} />);
+
+    expect(screen.getByText('今日から記録を始めましょう！')).toBeInTheDocument();
+  });
+
+  test('記録がない場合、エンプティステートを表示する', () => {
+    (statsCalculator.calculateStreak as jest.Mock).mockReturnValue(0);
+    (statsCalculator.countTotalEntries as jest.Mock).mockReturnValue(0);
+    (statsCalculator.countThisWeekEntries as jest.Mock).mockReturnValue(0);
+    (statsCalculator.countThisMonthEntries as jest.Mock).mockReturnValue(0);
+    (statsCalculator.countTotalItems as jest.Mock).mockReturnValue(0);
+
+    render(<StatsView entries={[]} isLoading={false} />);
+
+    expect(screen.getByText('まだ記録がありません')).toBeInTheDocument();
+    expect(screen.getByText(/「今日の記録」タブから/)).toBeInTheDocument();
+  });
+
+  test('ARIA属性が正しく設定されている', () => {
+    (statsCalculator.calculateStreak as jest.Mock).mockReturnValue(5);
+    (statsCalculator.countTotalEntries as jest.Mock).mockReturnValue(10);
+    (statsCalculator.countThisWeekEntries as jest.Mock).mockReturnValue(3);
+    (statsCalculator.countThisMonthEntries as jest.Mock).mockReturnValue(7);
+    (statsCalculator.countTotalItems as jest.Mock).mockReturnValue(30);
+
+    render(<StatsView entries={mockEntries} isLoading={false} />);
+
+    // region ロールを持つ要素が存在することを確認
+    const statsRegion = screen.getByRole('region', { name: '統計情報' });
+    expect(statsRegion).toBeInTheDocument();
+
+    // article ロールを持つ統計カードが存在することを確認
+    const articles = screen.getAllByRole('article');
+    expect(articles.length).toBeGreaterThan(0);
+  });
+});

--- a/src/hooks/useEntryView.ts
+++ b/src/hooks/useEntryView.ts
@@ -1,25 +1,27 @@
 import { useState, useEffect } from 'react';
 import type { DailyEntry } from '../types';
 
+export type ViewType = 'today' | 'history' | 'stats';
+
 export interface UseEntryViewReturn {
-  activeView: 'today' | 'history';
+  activeView: ViewType;
   selectedEntry: DailyEntry | null;
-  setActiveView: (view: 'today' | 'history') => void;
+  setActiveView: (view: ViewType) => void;
   selectEntry: (entry: DailyEntry | null) => void;
   clearSelection: () => void;
 }
 
 /**
  * ビュー管理フック
- * activeView（today/history）とselectedEntryの状態を管理する
+ * activeView（today/history/stats）とselectedEntryの状態を管理する
  */
 export function useEntryView(): UseEntryViewReturn {
-  const [activeView, setActiveView] = useState<'today' | 'history'>('today');
+  const [activeView, setActiveView] = useState<ViewType>('today');
   const [selectedEntry, setSelectedEntry] = useState<DailyEntry | null>(null);
 
-  // activeViewが'today'に変わったら自動でselectedEntryをクリア
+  // activeViewが'today'または'stats'に変わったら自動でselectedEntryをクリア
   useEffect(() => {
-    if (activeView === 'today') {
+    if (activeView === 'today' || activeView === 'stats') {
       setSelectedEntry(null);
     }
   }, [activeView]);

--- a/src/utils/__tests__/statsCalculator.test.ts
+++ b/src/utils/__tests__/statsCalculator.test.ts
@@ -1,0 +1,162 @@
+import {
+  calculateStreak,
+  countTotalEntries,
+  countThisWeekEntries,
+  countThisMonthEntries,
+  countTotalItems
+} from '../statsCalculator';
+import { DailyEntry } from '../../types';
+
+// テスト用のモックデータ
+const createMockEntry = (dateStr: string, itemCount: number = 3): DailyEntry => ({
+  date: dateStr,
+  items: Array(itemCount).fill(null).map((_, i) => ({
+    content: `良いこと${i + 1}`,
+    createdAt: new Date(dateStr),
+    hasRequestedComment: false
+  }))
+});
+
+// ヘルパー関数
+function getDateBefore(dateStr: string, days: number): string {
+  const date = new Date(dateStr);
+  date.setDate(date.getDate() - days);
+  return formatDate(date);
+}
+
+function getDateAfter(dateStr: string, days: number): string {
+  const date = new Date(dateStr);
+  date.setDate(date.getDate() + days);
+  return formatDate(date);
+}
+
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+describe('statsCalculator', () => {
+  describe('calculateStreak', () => {
+    test('今日記録がある場合、連続日数を正しく計算する', () => {
+      const today = new Date().toISOString().split('T')[0];
+      const yesterday = getDateBefore(today, 1);
+      const twoDaysAgo = getDateBefore(today, 2);
+
+      const entries = [
+        createMockEntry(today),
+        createMockEntry(yesterday),
+        createMockEntry(twoDaysAgo)
+      ];
+
+      expect(calculateStreak(entries)).toBe(3);
+    });
+
+    test('昨日記録があり今日はない場合、昨日までのストリークを計算する', () => {
+      const today = new Date().toISOString().split('T')[0];
+      const yesterday = getDateBefore(today, 1);
+      const twoDaysAgo = getDateBefore(today, 2);
+
+      const entries = [
+        createMockEntry(yesterday),
+        createMockEntry(twoDaysAgo)
+      ];
+
+      expect(calculateStreak(entries)).toBe(2);
+    });
+
+    test('今日も昨日も記録がない場合、ストリークは0', () => {
+      const threeDaysAgo = getDateBefore(new Date().toISOString().split('T')[0], 3);
+      const entries = [createMockEntry(threeDaysAgo)];
+
+      expect(calculateStreak(entries)).toBe(0);
+    });
+
+    test('空配列の場合、ストリークは0', () => {
+      expect(calculateStreak([])).toBe(0);
+    });
+
+    test('連続でない記録がある場合、直近の連続のみカウント', () => {
+      const today = new Date().toISOString().split('T')[0];
+      const yesterday = getDateBefore(today, 1);
+      const fourDaysAgo = getDateBefore(today, 4);  // 間が空いている
+
+      const entries = [
+        createMockEntry(today),
+        createMockEntry(yesterday),
+        createMockEntry(fourDaysAgo)
+      ];
+
+      expect(calculateStreak(entries)).toBe(2);  // 今日+昨日のみ
+    });
+  });
+
+  describe('countTotalEntries', () => {
+    test('総記録数を正しくカウントする', () => {
+      const entries = [
+        createMockEntry('2024-01-01'),
+        createMockEntry('2024-01-02'),
+        createMockEntry('2024-01-03')
+      ];
+
+      expect(countTotalEntries(entries)).toBe(3);
+    });
+
+    test('空配列の場合、0を返す', () => {
+      expect(countTotalEntries([])).toBe(0);
+    });
+  });
+
+  describe('countTotalItems', () => {
+    test('総項目数を正しくカウントする', () => {
+      const entries = [
+        createMockEntry('2024-01-01', 3),
+        createMockEntry('2024-01-02', 2),
+        createMockEntry('2024-01-03', 3)
+      ];
+
+      expect(countTotalItems(entries)).toBe(8);
+    });
+
+    test('空配列の場合、0を返す', () => {
+      expect(countTotalItems([])).toBe(0);
+    });
+  });
+
+  describe('countThisWeekEntries', () => {
+    test('今週の記録数を正しくカウントする', () => {
+      const today = new Date();
+      const sunday = new Date(today);
+      sunday.setDate(today.getDate() - today.getDay());
+
+      const sundayStr = formatDate(sunday);
+      const mondayStr = getDateAfter(sundayStr, 1);
+      const lastWeekStr = getDateBefore(sundayStr, 1);
+
+      const entries = [
+        createMockEntry(sundayStr),
+        createMockEntry(mondayStr),
+        createMockEntry(lastWeekStr)  // 先週（カウント外）
+      ];
+
+      expect(countThisWeekEntries(entries)).toBe(2);
+    });
+  });
+
+  describe('countThisMonthEntries', () => {
+    test('今月の記録数を正しくカウントする', () => {
+      const today = new Date();
+      const firstDay = new Date(today.getFullYear(), today.getMonth(), 1);
+      const lastMonth = new Date(today.getFullYear(), today.getMonth() - 1, 15);
+
+      const entries = [
+        createMockEntry(formatDate(firstDay)),
+        createMockEntry(formatDate(today)),
+        createMockEntry(formatDate(lastMonth))  // 先月（カウント外）
+      ];
+
+      expect(countThisMonthEntries(entries)).toBe(2);
+    });
+  });
+});

--- a/src/utils/statsCalculator.ts
+++ b/src/utils/statsCalculator.ts
@@ -1,0 +1,119 @@
+import type { DailyEntry } from '../types';
+
+/**
+ * 連続記録日数（ストリーク）を計算
+ * 今日から遡って、記録が途切れるまでの日数をカウント
+ *
+ * @param entries - 全エントリー（降順ソート済み）
+ * @returns 連続日数
+ */
+export function calculateStreak(entries: DailyEntry[]): number {
+  if (entries.length === 0) return 0;
+
+  // 今日の日付（YYYY-MM-DD形式）
+  const today = getCurrentDateString();
+
+  // 昨日の日付
+  const yesterday = getDateBefore(today, 1);
+
+  // 今日記録があるか確認
+  const hasToday = entries.some(e => e.date === today);
+
+  // 今日または昨日に記録がない場合はストリーク0
+  if (!hasToday && !entries.some(e => e.date === yesterday)) {
+    return 0;
+  }
+
+  // 今日から遡って連続日数を計算
+  let streak = 0;
+  let currentDate = hasToday ? today : yesterday;
+
+  while (true) {
+    const hasEntry = entries.some(e => e.date === currentDate);
+    if (!hasEntry) break;
+
+    streak++;
+    currentDate = getDateBefore(currentDate, 1);
+  }
+
+  return streak;
+}
+
+/**
+ * 総記録数をカウント
+ *
+ * @param entries - 全エントリー
+ * @returns 総記録数
+ */
+export function countTotalEntries(entries: DailyEntry[]): number {
+  return entries.length;
+}
+
+/**
+ * 今週の記録数をカウント（日曜日始まり）
+ *
+ * @param entries - 全エントリー
+ * @returns 今週の記録数
+ */
+export function countThisWeekEntries(entries: DailyEntry[]): number {
+  const today = new Date();
+  const sunday = new Date(today);
+  sunday.setDate(today.getDate() - today.getDay()); // 日曜日
+  sunday.setHours(0, 0, 0, 0);
+
+  const sundayStr = formatDate(sunday);
+
+  return entries.filter(e => e.date >= sundayStr).length;
+}
+
+/**
+ * 今月の記録数をカウント
+ *
+ * @param entries - 全エントリー
+ * @returns 今月の記録数
+ */
+export function countThisMonthEntries(entries: DailyEntry[]): number {
+  const today = new Date();
+  const firstDay = new Date(today.getFullYear(), today.getMonth(), 1);
+  const firstDayStr = formatDate(firstDay);
+
+  return entries.filter(e => e.date >= firstDayStr).length;
+}
+
+/**
+ * 総記録項目数をカウント（1日3項目 × 記録日数）
+ *
+ * @param entries - 全エントリー
+ * @returns 総項目数
+ */
+export function countTotalItems(entries: DailyEntry[]): number {
+  return entries.reduce((sum, entry) => sum + entry.items.length, 0);
+}
+
+// ヘルパー関数
+
+/**
+ * 現在の日付をYYYY-MM-DD形式で取得
+ */
+function getCurrentDateString(): string {
+  return formatDate(new Date());
+}
+
+/**
+ * Date オブジェクトを YYYY-MM-DD 形式に変換
+ */
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * 指定日付の N 日前の日付を取得
+ */
+function getDateBefore(dateStr: string, days: number): string {
+  const date = new Date(dateStr);
+  date.setDate(date.getDate() - days);
+  return formatDate(date);
+}


### PR DESCRIPTION
## 概要

Sprint 4のエンゲージメント機能として、統計表示機能（Phase 1: 基本統計）を実装しました。

## 実装内容

### 1. 統計計算ユーティリティ (statsCalculator.ts)
- **calculateStreak**: 連続記録日数を計算（今日/昨日の猶予期間あり）
- **countTotalEntries**: 総記録日数
- **countThisWeekEntries**: 今週の記録数（日曜日始まり）
- **countThisMonthEntries**: 今月の記録数
- **countTotalItems**: 記録した良いことの総数

### 2. StatsViewコンポーネント
- **プライマリカード（ストリーク）**: グラデーション背景で視覚的に強調
- **サブ統計グリッド**: 2×2レスポンシブグリッドで4つの統計を表示
- **パフォーマンス最適化**: useMemoで統計計算をメモ化
- **Material Design 3**: エレベーション、ホバーエフェクト、トランジション
- **ダークテーマ対応**: グラデーション調整で視認性確保
- **アクセシビリティ**: ARIA属性によるスクリーンリーダー対応

### 3. 3タブナビゲーション
- 「今日/履歴/統計」の3タブ構成に拡張
- useEntryViewフックで stats viewタイプをサポート
- 統計タブに切り替えると自動でselectedEntryをクリア

### 4. テスト実装
- **statsCalculator**: 11テスト（境界値、エッジケース、ストリーク中断など）
- **StatsView**: 5テスト（ローディング、表示、エンプティステート、ARIA属性）
- **テストパス率**: 100% (92/92 tests)

## 新規ファイル (5)
- `src/utils/statsCalculator.ts`
- `src/components/StatsView/StatsView.tsx`
- `src/components/StatsView/StatsView.css`
- `src/utils/__tests__/statsCalculator.test.ts`
- `src/components/StatsView/__tests__/StatsView.test.tsx`

## 変更ファイル (5)
- `src/hooks/useEntryView.ts` - ViewTypeに'stats'追加
- `src/App.tsx` - 統計タブと統計ビュー追加
- `src/App.css` - 3タブ対応のスタイル調整
- `.claude/progress.md` - Sprint 4 Phase 1完了記録
- `CLAUDE.md` - Sprint 4 Phase 1完了記録

## テスト結果

```
Test Suites: 16 passed, 16 total
Tests:       92 passed, 92 total
Snapshots:   0 total
Time:        ~3s
```

全てのテストが合格し、TypeScriptエラーもありません。

## 期待効果

- **継続率向上**: ストリークの可視化により記録継続のモチベーション向上
- **達成感の強化**: 総記録数・総項目数の表示により達成感を提供
- **週次・月次の振り返り**: 今週・今月の記録数で短期的な進捗を把握

継続率+25%向上を見込んでいます。

## 将来の拡張（Phase 2, 3）

- **Phase 2**: 月間カレンダービュー（記録した日のハイライト表示）
- **Phase 3**: 頻出ワード表示（よく使う言葉トップ10）

## スクリーンショット

（手動で追加予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>